### PR TITLE
Fix #8: now builds for people without a Mac Developer Account. Mac Devel...

### DIFF
--- a/Lin.xcodeproj/project.pbxproj
+++ b/Lin.xcodeproj/project.pbxproj
@@ -635,7 +635,6 @@
 		AA1B7DB617C3C1EC00A3A6D7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DSTROOT = "$(HOME)";
@@ -656,7 +655,6 @@
 		AA1B7DB717C3C1EC00A3A6D7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "3rd Party Mac Developer Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DSTROOT = "$(HOME)";


### PR DESCRIPTION
...oper code signing is not necessary for the application to build and install the plugin.
