### PR TITLE
Quick fix to suppress loading localisations from frameworks

### DIFF
--- a/Lin/LNLocalizationCollection.m
+++ b/Lin/LNLocalizationCollection.m
@@ -93,6 +93,13 @@
 {
     NSMutableSet *localizations = [NSMutableSet set];
     
+    // Don't load localizations from frameworks
+    if( [self.filePath rangeOfString:@".framework/"
+                             options:NSCaseInsensitiveSearch ].location != NSNotFound )
+    {
+        return;
+    };
+    
     // Load contents
     NSString *contents = [self loadContentsOfFile:self.filePath];
     


### PR DESCRIPTION
Quick fix to suppress loading localisations from frameworks as that hung the plug-in in lines 117/124.

I don't know what causes the infinite loop other than it kept appearing when loading localisations from localised frameworks such as HockeyApp.
