### PR TITLE
Fix loading issue

### DIFF
--- a/Lin/Lin.m
+++ b/Lin/Lin.m
@@ -560,9 +560,6 @@ static Lin *_sharedPlugin = nil;
         for (DVTFilePath *filePath in indexCollection) {
             NSString *pathString = filePath.pathString;
             
-            NSLog(@"pathString: %@", pathString);
-            [NSThread sleepForTimeInterval:0.001];
-            
             BOOL parseStringsFilesOutsideWorkspaceProject = YES;
             if (parseStringsFilesOutsideWorkspaceProject ||
                 (!parseStringsFilesOutsideWorkspaceProject && [pathString rangeOfString:projectRootPath].location != NSNotFound)) {


### PR DESCRIPTION
What I did is:
- Ignore .strings files whose encoding type cannot be detected (Maybe you don't need to load them in most cases)
- Replace `enumerateMatchesInString:options:range:usingBlock:` with `firstMatchInString:options:range:` because Lin only needs first match and it is lengthy.
