### PR TITLE
Fix infinite loop

### DIFF
--- a/Lin/Lin.m
+++ b/Lin/Lin.m
@@ -99,7 +99,7 @@ static Lin *_sharedPlugin = nil;
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(indexDidChangeState:)
-                                                     name:@"IDEIndexDidChangeStateNotification"
+                                                     name:@"IDEIndexDidIndexWorkspaceNotification"
                                                    object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(editorDocumentDidSave:)


### PR DESCRIPTION
I think it's better to listen to IDEIndexDidIndexWorkspaceNotification, this one is fired when Xcode finishes indexing the whole workspace, I tested it and it works with Pod.
