### PR TITLE
Remove successful load log

### DIFF
--- a/Lin/Lin.m
+++ b/Lin/Lin.m
@@ -131,10 +131,6 @@ static Lin *_sharedPlugin = nil;
                                                      name:NSMenuDidChangeItemNotification
                                                    object:nil];
         
-        // Show the version information
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-        NSLog(@"Lin ver.%@ was successfully loaded.", [bundle shortVersionString]);
-        
         // Activate if enabled
         if ([[LNUserDefaultsManager sharedManager] isEnabled]) {
             [self activate];


### PR DESCRIPTION
Command-line tools like _xcodebuild_ flood the logs every time Xcode needs to be loaded.

![screen shot 2014-04-01 at 11 16 11 am](https://cloud.githubusercontent.com/assets/241156/2577937/bedc80e6-b986-11e3-90ed-31fa35f971eb.png)
