### PR TITLE
Remove log statement on successful load

### DIFF
--- a/Lin/Lin.m
+++ b/Lin/Lin.m
@@ -131,10 +131,6 @@ static Lin *_sharedPlugin = nil;
                                                      name:NSMenuDidChangeItemNotification
                                                    object:nil];
         
-        // Show the version information
-        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-        NSLog(@"Lin ver.%@ was successfully loaded.", [bundle shortVersionString]);
-        
         // Activate if enabled
         if ([[LNUserDefaultsManager sharedManager] isEnabled]) {
             [self activate];


### PR DESCRIPTION
I like to run specs (`$ xcodebuild $ARGS test`) on the command line, and this little log statement chimes in every time. Can we remove it?
