### PR TITLE
Xcode 6.0.1 (6A317) support.

### DIFF
--- a/Lin/Lin-Info.plist
+++ b/Lin/Lin-Info.plist
@@ -27,6 +27,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string></string>


### PR DESCRIPTION
Added the UUID of Xcode 6.0.1 (6A317).
